### PR TITLE
Update to pdf.js 2.1.266

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ksyos/pdfjs-release",
-    "version": "2.0.943",
+    "version": "2.1.266",
     "description": "Prebuilt release from Mozilla's PDF.js repackaged as a node module",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Version 2.1.266 fixes https://github.com/mozilla/pdf.js/issues/10387, which causes CSP errors for us.