### PR TITLE
Update script to allow more assets

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,13 +4,18 @@ RELEASE=$(curl -s https://api.github.com/repos/mozilla/pdf.js/releases/latest)
 
 RELEASE_VERSION=$(echo "$RELEASE" | jq -r .name | cut -c 2-)
 
-if [[ $(echo "$RELEASE" | jq -r '.assets | length') != 1 ]]; then
+if [[ $(echo "$RELEASE" | jq -r '.assets | length') < 1 ]]; then
     echo "Unexpected number of assets for latest release ($RELEASE_VERSION)" >&2
     exit 1
 fi
 
 if [[ $(echo "$RELEASE" | jq -r '.assets[0].content_type') != *zip* ]]; then
     echo "Unexpected content type for latest release ($RELEASE_VERSION)" >&2
+    exit 1
+fi
+
+if [[ $(echo "$RELEASE" | jq -r '.assets[0].name') == *es5* ]]; then
+    echo "Unexpected asset name for latest release ($RELEASE_VERSION)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
On release [v2.1.266](https://api.github.com/repos/mozilla/pdf.js/releases/tags/v2.1.266) only one object was present in `assets`. Now, on latest release [v2.5.207](https://api.github.com/repos/mozilla/pdf.js/releases/tags/v2.5.207) we can see two objects. According to previous script we should use the asset whose name **does not** contain `es5` in its name, thus the new checks added.